### PR TITLE
drivers: icvs: add __packed attribute to ctrl_data_fwupd struct

### DIFF
--- a/include/linux/intel_cvs.h
+++ b/include/linux/intel_cvs.h
@@ -136,7 +136,7 @@ struct cvs_to_plugin_interface {
 	u16 pid;
 	int opid;
 	int dev_capabilities;
-};
+} __packed;
 
 /* Params updated by CVS plugin */
 struct plugin_to_cvs_interface {
@@ -144,7 +144,7 @@ struct plugin_to_cvs_interface {
 	int max_flash_time; /*milli sec*/
 	int max_fwupd_retry_count;
 	int fw_bin_fd; /*file descriptor*/
-};
+} __packed;
 
 /* FW update status Info */
 struct ctrl_data_fwupd {
@@ -156,7 +156,7 @@ struct ctrl_data_fwupd {
 	bool fw_dl_finshed;
 	/* 0:PASS, Non-zero error code. Read only after fw_dl finished=1 */
 	int fw_dl_status_code;
-};
+} __packed;
 
 struct intel_cvs {
 	struct device *dev;


### PR DESCRIPTION
The layout of both structs cannot be optimized by the compiler as this is exported as a binary blob into sysfs using memcpy.

This fixes updating the firwmare using fwupd.