### PR TITLE
Access i2c only for FULLCAP

### DIFF
--- a/drivers/misc/icvs/intel_cvs.c
+++ b/drivers/misc/icvs/intel_cvs.c
@@ -148,24 +148,27 @@ static int cvs_i2c_probe(struct i2c_client *i2c)
 		ret = cvs_init(icvs);
 		if (ret)
 			dev_err(icvs->dev, "Failed to initialize\n");
-		find_oem_prod_id(handle, "OPID", &icvs->oem_prod_id);
-	}
-	mdelay(FW_PREPARE_MS);
-	ret = cvs_find_magic_num_support(icvs);
-	if (ret)
-		goto exit;
 
-	if (icvs->magic_num_support) {
-		ret = cvs_get_device_cap(&icvs->cv_fw_capability);
+		find_oem_prod_id(handle, "OPID", &icvs->oem_prod_id);
+
+		ret = cvs_find_magic_num_support(icvs);
 		if (ret)
 			goto exit;
+
+		if (icvs->magic_num_support) {
+			ret = cvs_get_device_cap(&icvs->cv_fw_capability);
+			if (ret)
+				goto exit;
+		}
+
+		ret = cvs_write_i2c(SET_HOST_IDENTIFIER, NULL, 0);
+		if (ret) {
+			dev_err(cvs->dev, "%s:set_host_identifier cmd failed", __func__);
+			goto exit;
+		}
 	}
 
-	ret = cvs_write_i2c(SET_HOST_IDENTIFIER, NULL, 0);
-	if (ret) {
-		dev_err(cvs->dev, "%s:set_host_identifier cmd failed", __func__);
-		goto exit;
-	}
+	mdelay(FW_PREPARE_MS);
 
 	ret = cvs_acquire_camera_sensor_internal();
 	if (ret) {
@@ -175,6 +178,7 @@ static int cvs_i2c_probe(struct i2c_client *i2c)
 		dev_info(cvs->dev, "%s:Transfer of ownership success",
 			 __func__);
 	}
+
 	icvs->icvs_sensor_state = CV_SENSOR_VISION_ACQUIRED_STATE;
 	acpi_dev_clear_dependencies(ACPI_COMPANION(icvs->dev));
 


### PR DESCRIPTION
I2C access is only available if the resources are FULLCAP Avoid reading/writing through I2C and only perform the camera handshake.

HSD:15018357421